### PR TITLE
Limit categorical features in box-plot distributions

### DIFF
--- a/data_understand/dataset_characteristics/characteristics.py
+++ b/data_understand/dataset_characteristics/characteristics.py
@@ -46,15 +46,13 @@ def get_message_columns_having_missing_values(df: pd.DataFrame) -> str:
             if column in numerical_feature_list:
                 message += (
                     "- The missing values in column {0} "
-                    "could be imputed with mean/median value.\n").format(
-                        column
-                )
+                    "could be imputed with mean/median value.\n"
+                ).format(column)
             else:
                 message += (
                     "- The missing values in column {0} "
-                    "could be imputed with mode value.\n").format(
-                        column
-                )
+                    "could be imputed with mode value.\n"
+                ).format(column)
 
         return message
 

--- a/data_understand/jupyter_notebook_generator.py
+++ b/data_understand/jupyter_notebook_generator.py
@@ -52,8 +52,9 @@ def generate_jupyter_notebook(args: Any) -> None:
     """
     print("Generating jupyter notebook for the dataset in " + args.file_name)
     nb = v4.new_notebook()
-    nb.metadata["title"] = "Understanding the data in " + \
-        Path(args.file_name).name
+    nb.metadata["title"] = (
+        "Understanding the data in " + Path(args.file_name).name
+    )
 
     (
         dataframe_read_markdown,

--- a/data_understand/messages.py
+++ b/data_understand/messages.py
@@ -88,6 +88,9 @@ BOX_PLOT_DISTRIBUTION_MESSAGE = (
     "in a numerical column. These graphs help in uncovering "
     "patterns that exist between various categories in a "
     "categorical column with the values in the numerical columns."
+    "The categorical columns having 15 categories or less are choosen "
+    "for box plot distribution because the box plot visualization is "
+    "not useful for larger number of categories."
 )
 
 FEATURE_CORRELATION_MESSAGE = (

--- a/data_understand/value_distributions/box_plot_distribution.py
+++ b/data_understand/value_distributions/box_plot_distribution.py
@@ -10,6 +10,18 @@ from data_understand.utils import (construct_image_name,
                                    get_numerical_categorical_features)
 
 
+def _prune_categorical_feature_list(
+    df: pd.DataFrame, categorical_feature_list: List[str]
+) -> List[str]:
+    pruned_categorical_feature_list = []
+    for feature in categorical_feature_list:
+        counts = df[feature].value_counts()
+        if len(counts) <= 15:
+            pruned_categorical_feature_list.append(feature)
+
+    return pruned_categorical_feature_list
+
+
 def save_box_plot_distributions(
     df: pd.DataFrame, current_execution_uuid: str
 ) -> List[str]:
@@ -31,9 +43,13 @@ def save_box_plot_distributions(
         categorical_feature_list,
     ) = get_numerical_categorical_features(df)
 
+    pruned_categorical_feature_list = _prune_categorical_feature_list(
+        df, categorical_feature_list
+    )
+
     saved_image_name_list = []
     for numerical_feature in numerical_feature_list:
-        for categorical_feature in categorical_feature_list:
+        for categorical_feature in pruned_categorical_feature_list:
             sns.boxplot(x=numerical_feature, y=categorical_feature, data=df)
             plt.xlabel(numerical_feature)
             plt.ylabel(categorical_feature)
@@ -66,8 +82,13 @@ def generate_box_plot_distributions(df: pd.DataFrame) -> None:
         numerical_feature_list,
         categorical_feature_list,
     ) = get_numerical_categorical_features(df)
+
+    pruned_categorical_feature_list = _prune_categorical_feature_list(
+        df, categorical_feature_list
+    )
+
     for numerical_feature in numerical_feature_list:
-        for categorical_feature in categorical_feature_list:
+        for categorical_feature in pruned_categorical_feature_list:
             sns.boxplot(x=numerical_feature, y=categorical_feature, data=df)
             plt.xlabel(numerical_feature)
             plt.ylabel(categorical_feature)

--- a/tests/unit/test_box_plot_distribution.py
+++ b/tests/unit/test_box_plot_distribution.py
@@ -1,5 +1,11 @@
+import random
+
+import pandas as pd
+
 from data_understand.value_distributions import \
     get_jupyter_nb_code_to_generate_box_plot_distributions
+from data_understand.value_distributions.box_plot_distribution import \
+    _prune_categorical_feature_list
 
 
 class TestHistogramDistribution:
@@ -10,3 +16,46 @@ class TestHistogramDistribution:
         ) = get_jupyter_nb_code_to_generate_box_plot_distributions()
         assert isinstance(markdown, str)
         assert isinstance(code, str)
+
+    def test_prune_categorical_feature_list(self):
+        # Define the number of rows in the DataFrame
+        num_rows = 100
+
+        # Create a list of categories for each categorical column
+        categories_less_than_15 = ["Category_A", "Category_B", "Category_C"]
+        categories_exactly_15 = [f"Category_{i}" for i in range(1, 16)]
+        categories_more_than_15 = ["Category_XYZ", "Category_ABC"] + [
+            f"Category_{i}" for i in range(16, 31)
+        ]
+
+        # Create a dictionary to store data for each column
+        data = {
+            "Categorical_Column_1": random.choices(
+                categories_less_than_15, k=num_rows
+            ),
+            "Categorical_Column_2": random.choices(
+                categories_exactly_15, k=num_rows
+            ),
+            "Categorical_Column_3": random.choices(
+                categories_more_than_15, k=num_rows
+            ),
+            "Numeric_Column": [
+                random.randint(1, 100) for _ in range(num_rows)
+            ],
+        }
+
+        # Create the DataFrame
+        df = pd.DataFrame(data)
+
+        pruned_categorical_feature_list = _prune_categorical_feature_list(
+            df,
+            [
+                "Categorical_Column_1",
+                "Categorical_Column_2",
+                "Categorical_Column_3",
+            ],
+        )
+        assert pruned_categorical_feature_list == [
+            "Categorical_Column_1",
+            "Categorical_Column_2",
+        ]

--- a/tests/unit/test_characteristics.py
+++ b/tests/unit/test_characteristics.py
@@ -48,12 +48,21 @@ class TestDatasetCharacteristics:
         )
         output = get_message_columns_having_missing_values(df_missing_values)
         assert "The columns having missing values are: A,B" in output
-        assert "The missing values in column A could be imputed " + \
-            "with mean/median value." in output
-        assert "The missing values in column B could be imputed " + \
-            "with mean/median value." in output
-        assert "The missing values in column D could be imputed " +\
-            "with mode value." in output
+        assert (
+            "The missing values in column A could be imputed "
+            + "with mean/median value."
+            in output
+        )
+        assert (
+            "The missing values in column B could be imputed "
+            + "with mean/median value."
+            in output
+        )
+        assert (
+            "The missing values in column D could be imputed "
+            + "with mode value."
+            in output
+        )
 
         df_no_missing_values = pd.DataFrame(
             {"A": [1, 2, 3], "B": [4, 5, 5], "C": [4, 5, 9]}


### PR DESCRIPTION
Only categorical features having less than or equal to 15 categories are chosen for box-plot distributions.  